### PR TITLE
Modify AOSP part to use full https address

### DIFF
--- a/aosp.xml
+++ b/aosp.xml
@@ -2,7 +2,7 @@
 <manifest>
 
   <remote  name="aosp"
-           fetch=".."
+           fetch="https://android.googlesource.com"
            review="https://android-review.googlesource.com/" />
   <default revision="refs/tags/android-13.0.0_r83"
            remote="aosp"


### PR DESCRIPTION
By default, repo uses the address of the current manifest + ".." + aosp project path to obtain each project of aosp; if the manifest is not under the same path as other projects, there will be problems.